### PR TITLE
get it working

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM jhamrick/jupyterhub
+
+ADD docker_oauth.py /srv/oauthenticator/docker_oauth.py
+
+# override ONBUILD ADD while we work on the hub config
+ADD jupyterhub_config.py /srv/jupyterhub/jupyterhub_config.py

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+Custom OAuthenticator + DockerSpawner 
+
+To build the image, add userlist of the form:
+
+    username
+    username admin
+    username
+    ...
+
+And build:
+
+    docker build -t jupyterhub-system-docker
+
+Add your GitHub credentials to an `env` file:
+
+    GITHUB_CLIENT_ID=[something]
+    GITHUB_CLIENT_SECRET=[something-else]
+    OAUTH_CALLBACK_URL=http://[HOST]/hub/oauth_callback
+    JPY_COOKIE_SECRET=[abc123]
+
+Start the [restuser](https://github.com/minrk/restuser) service on the host:
+
+    python /path/to/restuser.py --socket=/var/run/restuser.sock
+
+And run JupyterHub:
+
+    docker run --net=host --env-file=env -v /var/run/docker.sock:/docker.sock -v /var/run/restuser.sock:/restuser.sock -it hub
+
+It will create real unix users on the host system on demand
+and start single-user docker containers,
+mounting each user's home directory.

--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -1,0 +1,40 @@
+# Configuration file for Jupyter Hub
+c = get_config()
+
+import os
+import sys
+
+# Base configuration
+c.JupyterHub.log_level = 10
+c.JupyterHub.admin_users = admin = set()
+
+# Configure the authenticator
+c.JupyterHub.authenticator_class = 'docker_oauth.DockerOAuthenticator'
+c.DockerOAuthenticator.oauth_callback_url = os.environ['OAUTH_CALLBACK_URL']
+c.DockerOAuthenticator.create_system_users = True
+c.Authenticator.whitelist = whitelist = set()
+
+# Configure the spawner
+c.JupyterHub.spawner_class = 'docker_oauth.SystemUserDockerSpawner'
+c.SystemUserSpawner.user_ids = userids = dict()
+c.SystemUserSpawner.container_image = 'jhamrick/systemuser'
+
+# The docker instances need access to the Hub, so the default loopback port
+# doesn't work:
+from IPython.utils.localinterfaces import public_ips
+c.JupyterHub.hub_ip = public_ips()[0]
+
+# Add users to the admin list, the whitelist, and also record their user ids
+root = os.environ.get('OAUTHENTICATOR_DIR', os.path.dirname(__file__))
+sys.path.insert(0, root)
+
+with open(os.path.join(root, 'userlist')) as f:
+    for line in f:
+        if line.isspace():
+            continue
+        parts = line.split()
+        name = parts[0]
+        whitelist.add(name)
+        if len(parts) > 1 and parts[1] == 'admin':
+            admin.add(name)
+


### PR DESCRIPTION
This PR includes some things that may not belong in this repo, but I wanted to make sure I committed everything I used to get it working.

Includes a README with the commands I used to start the server.

This adds a subclass of SystemDockerSpawner that stores the user_id in the user.state field in the database. That functionality may want to be added to the class in dockerspawner instead of creating a subclass.

The Authenticator writes the user_id to this field when the user is created.

With everything humming along, this shouldn't require the creation of any users beforehand, only populating the userlist file.
