### PR TITLE
commit db changes after changing user state

### DIFF
--- a/docker_oauth.py
+++ b/docker_oauth.py
@@ -61,6 +61,7 @@ class DockerAuthenticator(LocalAuthenticator):
         if user.state is None:
             user.state = {}
         user.state['user_id'] = info['uid']
+        self.db.commit()
 
 
 class DockerOAuthenticator(DockerAuthenticator, GitHubOAuthenticator):


### PR DESCRIPTION
db changes were not being committed, and were eventually being rolled back

should address recent issues of uid not being recorded on add_user from the UI
